### PR TITLE
fix links in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We are fully committed to open-source. That means you can view all our code, com
 
 Every tech interview involves some kind of code screening. We do it differently at Jina. Since we are completely open-source, it is a good way to evaluate your engineering skills based on your first Pull Request to Jina.
 
-If you apply for one of our engineering roles, you can pick one project ([Jina](https://github.com/jina-ai/jina), [Jina-Hub](https://github.com/jina-ai/jina-hub), [Dashboard](https://github.com/jina-ai/jina-hub), [Examples](https://github.com/jina-ai/examples)) and work on one bug or new feature. Submit your work via pull request and pass the CICD. Then we will review it.
+If you apply for one of our engineering roles, you can pick one project ([Jina](https://github.com/jina-ai/jina), [Jina-Hub](https://github.com/jina-ai/jina-hub), [Dashboard](https://github.com/jina-ai/dashboard), [Examples](https://github.com/jina-ai/examples)) and work on one bug or new feature. Submit your work via pull request and pass the CICD. Then we will review it.
 
 Note that not only the code, but also the coding style, documentations, [commit style](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md), affect our evaluation.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,7 +46,7 @@ Jina AI是一家**神经搜索**公司。
 
 Code interview是技术面试必不可少的一项。在Jina，我们在尝试一种新的做法。因为我们是完全开源的，所以我们会根据你对Jina的第一次Pull Request来评估你的工程技能。
 
-如果你希望应聘我们的工程师岗位，你可以从以下项目中选择一个([Jina](https://github.com/jina-ai/jina)，[Hub](https://github.com/jina-ai/jina-hub)，[Dashboard](https://github.com/jina-ai/jina-hub)，[Examples](https://github.com/jina-ai/examples))，修正一个BUG或提出一个新功能。我们会对你的Pull Request进行及时的评估，根据PR的水平对评估你的技术能力。我们不仅会检查编码的功能实现，而且会特别关注编码风格以及文档风格。请参考我们的[Commit Style](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)。
+如果你希望应聘我们的工程师岗位，你可以从以下项目中选择一个([Jina](https://github.com/jina-ai/jina)，[Hub](https://github.com/jina-ai/jina-hub)，[Dashboard](https://github.com/jina-ai/dashboard)，[Examples](https://github.com/jina-ai/examples))，修正一个BUG或提出一个新功能。我们会对你的Pull Request进行及时的评估，根据PR的水平对评估你的技术能力。我们不仅会检查编码的功能实现，而且会特别关注编码风格以及文档风格。请参考我们的[Commit Style](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)。
 
 ### 从哪里入手
 


### PR DESCRIPTION
The link to the dashboard repo linked to Jina Hub instead. Fixed it to link to Dashbord repo.